### PR TITLE
Just round to the nearest int for percentages

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -369,8 +369,6 @@ cvr.getShield = function ( linePercent, minPassingLinePercent, callback )
         valueBgColor: valueBgColor,
         value: linePercent || "new",
         name: "line cvr",
-        nameWidth: 60,
-        fontSize: 12,
-        fontFamily: "Verdana, sans-serif"
+        nameWidth: 60
     }, callback );
 };


### PR DESCRIPTION
So we don’t get badges like this:

![dumb](https://www.evernote.com/l/AAGadHzhiG1D0Ld_YQv89nhBSf5g_o22b4EB/image.png)
