### PR TITLE
Fix shell script type

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -316,6 +316,7 @@ cvr.getFileType = function ( filePath )
 {
     var types = {
         sh: "bash",
+        bash: "bash",
         css: "css",
         go: "go",
         js: "javascript",

--- a/source/index.js
+++ b/source/index.js
@@ -321,7 +321,7 @@ cvr.getFileType = function ( filePath )
         js: "javascript",
         less: "less",
         md: "markdown",
-        python: "python",
+        py: "python",
         sql: "sql"
     };
 

--- a/source/index.js
+++ b/source/index.js
@@ -315,7 +315,7 @@ cvr.linesMissing = function ( coverage )
 cvr.getFileType = function ( filePath )
 {
     var types = {
-        bash: "bash",
+        sh: "bash",
         css: "css",
         go: "go",
         js: "javascript",

--- a/test/test.js
+++ b/test/test.js
@@ -169,21 +169,22 @@ describe( "File type checking", function()
 {
     it( "should return correct file type", function( done )
     {
-        var fileNames = {
-            bash: "script.sh",
-            css: "my-styles.css",
-            go: "main.go",
-            javascript: "index.js",
-            less: "my-style.less",
-            markdown: "README.md",
-            python: "urls.py",
-            sql: "V34__Create_sp_insert_data.sql",
-            clike: "Some_other_file.xcode"
+        var fileTypes = {
+            "my-style.less": "less",
+            "my-styles.css": "css",
+            "main.go": "go",
+            "Some_other_file.xcode": "clike",
+            "urls.py": "python",
+            "V34__Create_sp_insert_data.sql": "sql",
+            "script.sh": "bash",
+            "other-script.bash": "bash",
+            "README.md": "markdown", 
+            "index.js": "javascript"
         };
 
-        for ( var type in fileNames )
+        for ( var name in fileTypes )
         {
-            assert.equal( type, cvr.getFileType( fileNames[ type ] ) );
+            assert.equal( fileTypes[ name ], cvr.getFileType( name ) );
         };
         done();
     } );

--- a/test/test.js
+++ b/test/test.js
@@ -164,3 +164,27 @@ describe( "git", function ()
         } );
     } );
 } );
+
+describe( "File type checking", function()
+{
+    it( "should return correct file type", function( done )
+    {
+        var fileNames = {
+            bash: "script.sh",
+            css: "my-styles.css",
+            go: "main.go",
+            javascript: "index.js",
+            less: "my-style.less",
+            markdown: "README.md",
+            python: "urls.py",
+            sql: "V34__Create_sp_insert_data.sql",
+            clike: "Some_other_file.xcode"
+        };
+
+        for ( var type in fileNames )
+        {
+            assert.equal( type, cvr.getFileType( fileNames[ type ] ) );
+        };
+        done();
+    } );
+} );

--- a/test/test.js
+++ b/test/test.js
@@ -171,6 +171,7 @@ describe( "File type checking", function()
     {
         var fileNames = {
             bash: "script.sh",
+            bash: "other_script.bash",
             css: "my-styles.css",
             go: "main.go",
             javascript: "index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -171,7 +171,6 @@ describe( "File type checking", function()
     {
         var fileNames = {
             bash: "script.sh",
-            bash: "other_script.bash",
             css: "my-styles.css",
             go: "main.go",
             javascript: "index.js",


### PR DESCRIPTION
Following on from #35, shell scripts typically end in `.sh`, not `.bash`. Also added a test for filetype mapping.

@jrit 